### PR TITLE
Use a build matrix for the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,6 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
-        with:
-          cmake-version: "3.16.x"
       - name: Cmake Makefiles
         run: cd ./sbgECom/projects/unix; cmake -G 'Unix Makefiles'
       - name: Run make
@@ -50,10 +46,6 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
-        with:
-          cmake-version: "3.16.x"
       # Build the project
       - name: "${{ matrix.name }}: Cmake Makefiles"
         run: ${{ matrix.append }} cd ./sbgECom/projects/unix; cmake -G 'Unix Makefiles'


### PR DESCRIPTION
The current build workflow has some steps that are extremely similar, except for different environment variables. To simplify a bit the file and potentially speed up the CI checks, I used a build matrix. This allows removing the repetition in the workflow steps and running all those builds in parallel.

Note, I also removed the action which installs CMake. It seemed to be unnecessary because the ubuntu-latest image already includes CMake. If there was another reason to have it there, just add it back.