### PR TITLE
add a servo control project to test the servos using hotfire configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(RocketCode2020 C CXX)
 
 add_subdirectory(./libraries)
 
+if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
+	add_definitions(-D SERVO_CONTROL)
+endif()
 
 if (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
 	add_definitions(-D HOTFIRE_TEST)
@@ -44,7 +47,9 @@ endif()
 # ---------------
 find_package (Threads)
 
-if (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
+if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
+	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/ServoControl/*.cpp)
+elseif (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
 	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/HotFire/*.cpp)
 else()
 	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/OctoberSky1/*.cpp)
@@ -56,7 +61,14 @@ add_library(MainLoopLib ${SRC_MAIN} ${MAIN_CONFIG_SRC})
 
 target_include_directories(MainLoopLib PUBLIC ./src/)
 
-if (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
+if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
+	target_include_directories(MainLoopLib PUBLIC
+			./projects/ServoControl/
+	)
+	target_include_directories(MainLoopLib PUBLIC
+			./projects/HotFire/
+	)
+elseif (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
 	target_include_directories(MainLoopLib PUBLIC
 			./projects/HotFire/
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(RocketCode2020 C CXX)
 add_subdirectory(./libraries)
 
 if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
-	add_definitions(-D SERVO_CONTROL)
+	add_compile_definitions(-D SERVO_CONTROL=$ENV{SERVO_CONTROL})
 endif()
 
 if (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)

--- a/projects/HotFire/config/GpioConfig.h
+++ b/projects/HotFire/config/GpioConfig.h
@@ -11,12 +11,14 @@
 
     #define USE_OUT1 1
 
+    #define EVENT_ENABLE_MASK 1
 
     #if USE_PWM1
         #define PWM1_NAME "Valve404"
         #define PWM1_PIN 12
         #define PWM1_OPEN 150
         #define PWM1_CLOSE 60
+        #define PWM1_EVENT_ENABLE_MASK 0b100
     #endif
 
     #if USE_PWM2
@@ -24,6 +26,7 @@
         #define PWM2_PIN 13
         #define PWM2_OPEN 150
         #define PWM2_CLOSE 6
+        #define PWM2_EVENT_ENABLE_MASK 0b1000
     #endif
 
     #if USE_OUT1
@@ -31,6 +34,7 @@
         #define OUT1_PIN 16
         #define OUT1_OPEN 1
         #define OUT1_CLOSE 0
+        #define OUT1_EVENT_ENABLE_MASK 0b10
     #endif
 
 #endif

--- a/projects/ServoControl/config/UOStateMachine.cpp
+++ b/projects/ServoControl/config/UOStateMachine.cpp
@@ -26,17 +26,17 @@ STATE_DEFINE(UOStateMachine, Init, UOSMData)
 {
     interface->initialize();
 
-#if USE_GPIO
+#if USE_GPIO == 1
 
-#if USE_PWM1
+#if USE_PWM1 == 1
     interface->createNewGpioPwmOutput(PWM1_NAME, PWM1_PIN);
 #endif
 
-#if USE_PWM2
+#if USE_PWM2 == 1
     interface->createNewGpioPwmOutput(PWM2_NAME, PWM2_PIN);
 #endif
 
-#if USE_OUT1
+#if USE_OUT1 == 1
     interface->createNewGpioOutput(OUT1_NAME, OUT1_PIN);
 #endif
 
@@ -87,28 +87,28 @@ STATE_DEFINE(UOStateMachine, Control, UOSMData)
 
     /*
      * GPIO event number, a 4 bit binary number where the
-     * 4th bit is the enable bit and the first 3 control
+     * 1st bit is the enable bit and the last 3 control
      * whether the PWM2, PWM1, and OUT1 are open/closed.
      * A '1' means to open the valve and a '0' to close it.
      *
      * 0 0 0 0
-     * | | | ^--------- OUT1
-     * | | ^----------- PWM1
-     * | ^------------- PWM2
-     * ^--------------- Enable bit
+     * | | | ^--------- Enable bit
+     * | | ^----------- OUT1
+     * | ^------------- PWM1
+     * ^--------------- PWM2
      */
 
-#if USE_GPIO
+#if USE_GPIO == 1
     GpioData& gpioData = interfaceData->gpioData;
 
     // Check if enable bit is set
-    bool enabled = eventNbr > 0 && (eventNbr & 0b1000);
+    bool enabled = eventNbr > 0 && (eventNbr & EVENT_ENABLE_MASK);
 
-#if USE_OUT1
+#if USE_OUT1 == 1
     if (enabled)
     {
         // Open OUT1 is the first bit is set
-        bool open = eventNbr & 0b1;
+        bool open = eventNbr & OUT1_EVENT_ENABLE_MASK;
 
         gpioData.outputMap.insert({OUT1_NAME, open ? OUT1_OPEN : OUT1_CLOSE});
 
@@ -116,11 +116,11 @@ STATE_DEFINE(UOStateMachine, Control, UOSMData)
     }
 #endif
 
-#if USE_PWM1
+#if USE_PWM1 == 1
     if (enabled)
     {
         // Open PWM2 if the second bit is set
-        bool open = eventNbr & 0b10;
+        bool open = eventNbr & PWM1_EVENT_ENABLE_MASK;
 
         gpioData.pwmOutputMap.insert({PWM1_NAME, open ? PWM1_OPEN : PWM1_CLOSE});
 
@@ -128,11 +128,11 @@ STATE_DEFINE(UOStateMachine, Control, UOSMData)
     }
 #endif
 
-#if USE_PWM2
+#if USE_PWM2 == 1
     if (enabled)
     {
         // Open PWM2 if the third bit is set
-        bool open = eventNbr & 0b100;
+        bool open = eventNbr & PWM2_EVENT_ENABLE_MASK;
 
         gpioData.pwmOutputMap.insert({PWM2_NAME, open ? PWM2_OPEN : PWM2_CLOSE});
 

--- a/projects/ServoControl/config/UOStateMachine.cpp
+++ b/projects/ServoControl/config/UOStateMachine.cpp
@@ -26,21 +26,21 @@ STATE_DEFINE(UOStateMachine, Init, UOSMData)
 {
     interface->initialize();
 
-#if USE_GPIO == 1
+    #if USE_GPIO == 1
 
-#if USE_PWM1 == 1
-    interface->createNewGpioPwmOutput(PWM1_NAME, PWM1_PIN);
-#endif
+        #if USE_PWM1 == 1
+            interface->createNewGpioPwmOutput(PWM1_NAME, PWM1_PIN);
+        #endif
 
-#if USE_PWM2 == 1
-    interface->createNewGpioPwmOutput(PWM2_NAME, PWM2_PIN);
-#endif
+        #if USE_PWM2 == 1
+            interface->createNewGpioPwmOutput(PWM2_NAME, PWM2_PIN);
+        #endif
 
-#if USE_OUT1 == 1
-    interface->createNewGpioOutput(OUT1_NAME, OUT1_PIN);
-#endif
+        #if USE_OUT1 == 1
+            interface->createNewGpioOutput(OUT1_NAME, OUT1_PIN);
+        #endif
 
-#endif
+    #endif
 
     InternalEvent(ST_WAIT_FOR_INIT);
 }
@@ -98,49 +98,49 @@ STATE_DEFINE(UOStateMachine, Control, UOSMData)
      * ^--------------- PWM2
      */
 
-#if USE_GPIO == 1
-    GpioData& gpioData = interfaceData->gpioData;
+    #if USE_GPIO == 1
+        GpioData& gpioData = interfaceData->gpioData;
 
-    // Check if enable bit is set
-    bool enabled = eventNbr > 0 && (eventNbr & EVENT_ENABLE_MASK);
+        // Check if enable bit is set
+        bool enabled = eventNbr > 0 && (eventNbr & EVENT_ENABLE_MASK);
 
-#if USE_OUT1 == 1
-    if (enabled)
-    {
-        // Open OUT1 is the first bit is set
-        bool open = eventNbr & OUT1_EVENT_ENABLE_MASK;
+        #if USE_OUT1 == 1
+            if (enabled)
+            {
+                // Open OUT1 is the first bit is set
+                bool open = eventNbr & OUT1_EVENT_ENABLE_MASK;
 
-        gpioData.outputMap.insert({OUT1_NAME, open ? OUT1_OPEN : OUT1_CLOSE});
+                gpioData.outputMap.insert({OUT1_NAME, open ? OUT1_OPEN : OUT1_CLOSE});
 
-        std::cout << "ServoControlSM::Control OUT1 " << (open ? "OPEN" : "CLOSE") << "\n";
-    }
-#endif
+                std::cout << "ServoControlSM::Control OUT1 " << (open ? "OPEN" : "CLOSE") << "\n";
+            }
+        #endif
 
-#if USE_PWM1 == 1
-    if (enabled)
-    {
-        // Open PWM2 if the second bit is set
-        bool open = eventNbr & PWM1_EVENT_ENABLE_MASK;
+        #if USE_PWM1 == 1
+            if (enabled)
+            {
+                // Open PWM2 if the second bit is set
+                bool open = eventNbr & PWM1_EVENT_ENABLE_MASK;
 
-        gpioData.pwmOutputMap.insert({PWM1_NAME, open ? PWM1_OPEN : PWM1_CLOSE});
+                gpioData.pwmOutputMap.insert({PWM1_NAME, open ? PWM1_OPEN : PWM1_CLOSE});
 
-        std::cout << "ServoControlSM::Control PWM1 " << (open ? "OPEN" : "CLOSE") << "\n";
-    }
-#endif
+                std::cout << "ServoControlSM::Control PWM1 " << (open ? "OPEN" : "CLOSE") << "\n";
+            }
+        #endif
 
-#if USE_PWM2 == 1
-    if (enabled)
-    {
-        // Open PWM2 if the third bit is set
-        bool open = eventNbr & PWM2_EVENT_ENABLE_MASK;
+        #if USE_PWM2 == 1
+            if (enabled)
+            {
+                // Open PWM2 if the third bit is set
+                bool open = eventNbr & PWM2_EVENT_ENABLE_MASK;
 
-        gpioData.pwmOutputMap.insert({PWM2_NAME, open ? PWM2_OPEN : PWM2_CLOSE});
+                gpioData.pwmOutputMap.insert({PWM2_NAME, open ? PWM2_OPEN : PWM2_CLOSE});
 
-        std::cout << "ServoControlSM::Control PWM2 " << (open ? "OPEN" : "CLOSE") << "\n";
-    }
-#endif
+                std::cout << "ServoControlSM::Control PWM2 " << (open ? "OPEN" : "CLOSE") << "\n";
+            }
+        #endif
 
-#endif
+    #endif
 
     interface->updateOutputs(interfaceData);
 }

--- a/projects/ServoControl/config/UOStateMachine.cpp
+++ b/projects/ServoControl/config/UOStateMachine.cpp
@@ -1,0 +1,290 @@
+#define NOMINMAX // Fix issues on Windows with std:min and std:max
+
+#include <wiringPi.h>
+#include "config/config.h"
+#include "config/GpioConfig.h"
+#include "UOStateMachine.h"
+#include <iostream>
+#include "data/sensorsData.h"
+#include "helpers/Types.h"
+#include "data/GpioData.h"
+
+UOStateMachine::UOStateMachine() :
+        InterfacingStateMachine(ST_MAX_STATES), interfaceImpl()
+{
+
+    // There is no state entry function for the first state
+    enterNewState(States(0));
+
+    interface = &interfaceImpl;
+}
+
+// StartFilling external event
+void UOStateMachine::StartFillingEXT()
+{
+    BEGIN_TRANSITION_MAP					    // - Current State -
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED) // ST_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED) // ST_WAIT_FOR_INIT
+            TRANSITION_MAP_ENTRY(ST_FILLING)	// ST_WAIT_FOR_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED) // ST_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED) // ST_DONE
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED) // ST_ABORT_FILLING
+    END_TRANSITION_MAP(NULL)
+}
+
+// StopFilling external event
+void UOStateMachine::StopFillingEXT()
+{
+    BEGIN_TRANSITION_MAP						       // - Current State -
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		   // ST_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		   // ST_WAIT_FOR_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		   // ST_WAIT_FOR_FILLING
+            TRANSITION_MAP_ENTRY(ST_DONE)              // ST_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		   // ST_DONE
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		   // ST_ABORT_FILLING
+    END_TRANSITION_MAP(NULL)
+}
+
+// AbortFilling external event
+void UOStateMachine::AbortFillingEXT()
+{
+    BEGIN_TRANSITION_MAP					       // - Current State -
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)	   // ST_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)	   // ST_WAIT_FOR_INIT
+            TRANSITION_MAP_ENTRY(ST_ABORT_FILLING) // ST_WAIT_FOR_FILLING
+            TRANSITION_MAP_ENTRY(ST_ABORT_FILLING) // ST_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)	   // ST_DONE
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)	   // ST_ABORT_FILLING
+    END_TRANSITION_MAP(NULL)
+}
+
+// Done external event
+void UOStateMachine::DoneEXT(){
+    BEGIN_TRANSITION_MAP					        // - Current State -
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)     // ST_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		// ST_WAIT_FOR_INIT
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		// ST_WAIT_FOR_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		// ST_FILLING
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		// ST_DONE
+            TRANSITION_MAP_ENTRY(EVENT_IGNORED)		// ST_ABORT_FILLING
+    END_TRANSITION_MAP(NULL)
+}
+
+// Code for each state. Do not put while in them. The right function according to the current state
+// will be call in the main loop.
+
+STATE_DEFINE(UOStateMachine, Init, UOSMData)
+{
+    interface->initialize();
+#if USE_GPIO
+
+#if USE_PWM1
+    interface->createNewGpioPwmOutput(PWM1_NAME, PWM1_PIN);
+#endif
+
+#if USE_PWM2
+    interface->createNewGpioPwmOutput(PWM2_NAME, PWM2_PIN);
+#endif
+
+#if USE_OUT1
+    interface->createNewGpioOutput(OUT1_NAME, OUT1_PIN);
+#endif
+
+#endif
+
+    InternalEvent(ST_WAIT_FOR_INIT);
+}
+
+EXIT_DEFINE(UOStateMachine, ExitInit)
+{
+    std::cout << "ServoControlSM::ExitInit\n";
+}
+
+ENTRY_DEFINE(UOStateMachine, EnterWaitForInit, UOSMData)
+{
+    std::cout << "ServoControlSM::EnterWaitForInit\n";
+    enterNewState(ST_WAIT_FOR_INIT);
+}
+
+STATE_DEFINE(UOStateMachine, WaitForInit, UOSMData)
+{
+    interfaceData = updateInterface(data, ST_WAIT_FOR_INIT);
+#if USE_GPIO
+    GpioData& gpioData = interfaceData->gpioData;
+
+#if USE_PWM1
+    gpioData.pwmOutputMap.insert({PWM1_NAME, PWM1_OPEN});
+#endif
+
+#if USE_PWM2
+    gpioData.pwmOutputMap.insert({PWM2_NAME, PWM2_OPEN});
+#endif
+
+#if USE_OUT1
+    gpioData.outputMap.insert({OUT1_NAME, OUT1_OPEN});
+#endif
+
+#endif
+
+    if (interface->isInitialized())
+    {
+        InternalEvent(ST_WAIT_FOR_FILLING);
+    }
+
+    // showInfo(interfaceData);
+
+    interface->updateOutputs(interfaceData);
+}
+
+EXIT_DEFINE(UOStateMachine, ExitWaitForInit)
+{
+    std::cout << "ServoControlSM::ExitWaitForInit\n";
+}
+
+ENTRY_DEFINE(UOStateMachine, EnterWaitForFilling, UOSMData)
+{
+    std::cout << "ServoControlSM::EnterWaitForFilling\n";
+    enterNewState(ST_WAIT_FOR_FILLING);
+}
+
+STATE_DEFINE(UOStateMachine, WaitForFilling, UOSMData)
+{
+    interfaceData = updateInterface(data, ST_WAIT_FOR_FILLING);
+
+#if USE_GPIO
+    GpioData& gpioData = interfaceData->gpioData;
+
+#if USE_PWM1
+    gpioData.pwmOutputMap.insert({PWM1_NAME, PWM1_OPEN});
+#endif
+
+#if USE_PWM2
+    gpioData.pwmOutputMap.insert({PWM2_NAME, PWM2_OPEN});
+#endif
+
+#if USE_OUT1
+    gpioData.outputMap.insert({OUT1_NAME, OUT1_OPEN});
+#endif
+
+#endif
+
+    detectExternEvent(interfaceData);
+
+    interface->updateOutputs(interfaceData);
+}
+
+EXIT_DEFINE(UOStateMachine, ExitWaitForFilling)
+{
+    std::cout << "ServoControlSM::ExitWaitForFilling\n";
+}
+
+ENTRY_DEFINE(UOStateMachine, EnterFilling, UOSMData)
+{
+    std::cout << "ServoControlSM::EnterFilling\n";
+    enterNewState(ST_FILLING);
+}
+
+STATE_DEFINE(UOStateMachine, Filling, UOSMData)
+{
+    interfaceData = updateInterface(data, ST_FILLING);
+
+#if USE_GPIO
+    GpioData& gpioData = interfaceData->gpioData;
+
+#if USE_PWM1
+    gpioData.pwmOutputMap.insert({PWM1_NAME, PWM1_CLOSE});
+#endif
+
+#if USE_PWM2
+    gpioData.pwmOutputMap.insert({PWM2_NAME, PWM2_CLOSE});
+#endif
+
+#if USE_OUT1
+    gpioData.outputMap.insert({OUT1_NAME, OUT1_CLOSE});
+#endif
+
+#endif
+
+    detectExternEvent(interfaceData);
+
+    interface->updateOutputs(interfaceData);
+}
+
+EXIT_DEFINE(UOStateMachine, ExitFilling)
+{
+    std::cout << "ServoControlSM::ExitFilling\n";
+}
+
+ENTRY_DEFINE(UOStateMachine, EnterDone, UOSMData)
+{
+    std::cout << "ServoControlSM::EnterDone\n";
+    std::cout << "Done.\n";
+    enterNewState(ST_DONE);
+}
+
+STATE_DEFINE(UOStateMachine, Done, UOSMData)
+{
+    interfaceData = updateInterface(data, ST_DONE);
+
+    interface->updateOutputs(interfaceData);
+}
+
+ENTRY_DEFINE(UOStateMachine, EnterAbortFilling, UOSMData)
+{
+    std::cout << "ServoControlSM::EnterAbortFilling\n";
+    enterNewState(ST_ABORT_FILLING);
+}
+
+STATE_DEFINE(UOStateMachine, AbortFilling, UOSMData)
+{
+    interfaceData = updateInterface(data, ST_ABORT_FILLING);
+
+    detectExternEvent(interfaceData);
+
+    interface->updateOutputs(interfaceData);
+}
+
+void UOStateMachine::detectExternEvent(std::shared_ptr<sensorsData> data)
+{
+    eventType eventNbr = data->eventNumber;
+
+    switch (eventNbr)
+    {
+        case 0:
+            StartFillingEXT();
+            break;
+        case 1:
+            StopFillingEXT();
+            break;
+        case 4:
+            DoneEXT();
+            break;
+        case 5:
+            AbortFillingEXT();
+            break;
+        default:
+            break;
+    }
+}
+
+void UOStateMachine::showInfo(std::shared_ptr<sensorsData> data)
+{
+}
+
+void UOStateMachine::updateHotFire(UOSMData *data)
+{
+    ExecuteCurrentState(data);
+}
+
+std::shared_ptr<sensorsData> UOStateMachine::updateInterface(const UOSMData *smdata, States state)
+{
+    interface->updateInputs();
+    std::shared_ptr<sensorsData> data = interface->getLatest();
+
+    // If statement to prevent overwiring data from TESTING
+    if (data->timeStamp == -1) data->timeStamp = smdata->now.time_since_epoch().count();
+
+    data->currentStateNo = state;
+
+    return data;
+}

--- a/projects/ServoControl/config/UOStateMachine.h
+++ b/projects/ServoControl/config/UOStateMachine.h
@@ -10,12 +10,6 @@ class UOStateMachine : public InterfacingStateMachine
 public:
     UOStateMachine();
 
-    // External events taken by this state machine
-    void StartFillingEXT();
-    void StopFillingEXT();
-    void AbortFillingEXT();
-    void DoneEXT();
-
     void updateHotFire(UOSMData *data);
 
 protected:
@@ -27,19 +21,11 @@ protected:
 #endif
 
 private:
-    void detectExternEvent(std::shared_ptr<sensorsData> data);
-    void showInfo(std::shared_ptr<sensorsData> data);
-
-    // State enumeration order must match the order of state method entries
-    // in the state map.
     enum States
     {
         ST_INIT,
         ST_WAIT_FOR_INIT,
-        ST_WAIT_FOR_FILLING,
-        ST_FILLING,
-        ST_DONE,
-        ST_ABORT_FILLING,
+        ST_CONTROL,
         ST_MAX_STATES
     };
 
@@ -51,28 +37,14 @@ private:
     ENTRY_DECLARE(UOStateMachine, EnterWaitForInit, UOSMData)
     STATE_DECLARE(UOStateMachine, WaitForInit, UOSMData)
     EXIT_DECLARE(UOStateMachine, ExitWaitForInit)
-    // WaitForFilling
-    ENTRY_DECLARE(UOStateMachine, EnterWaitForFilling, UOSMData)
-    STATE_DECLARE(UOStateMachine, WaitForFilling, UOSMData)
-    EXIT_DECLARE(UOStateMachine, ExitWaitForFilling)
-    // Filling
-    ENTRY_DECLARE(UOStateMachine, EnterFilling, UOSMData)
-    STATE_DECLARE(UOStateMachine, Filling, UOSMData)
-    EXIT_DECLARE(UOStateMachine, ExitFilling)
-    // Done
-    ENTRY_DECLARE(UOStateMachine, EnterDone, UOSMData)
-    STATE_DECLARE(UOStateMachine, Done, UOSMData)
-    // AbortFilling
-    ENTRY_DECLARE(UOStateMachine, EnterAbortFilling, UOSMData)
-    STATE_DECLARE(UOStateMachine, AbortFilling, UOSMData)
+    // Control
+    ENTRY_DECLARE(UOStateMachine, EnterControl, UOSMData)
+    STATE_DECLARE(UOStateMachine, Control, UOSMData)
 
     BEGIN_STATE_MAP_EX
     STATE_MAP_ENTRY_ALL_EX(&Init, 0, 0, &ExitInit)
     STATE_MAP_ENTRY_ALL_EX(&WaitForInit, 0, &EnterWaitForInit, &ExitWaitForInit)
-    STATE_MAP_ENTRY_ALL_EX(&WaitForFilling, 0, &EnterWaitForFilling, &ExitWaitForFilling)
-    STATE_MAP_ENTRY_ALL_EX(&Filling, 0, &EnterFilling, &ExitFilling)
-    STATE_MAP_ENTRY_ALL_EX(&Done, 0, &EnterDone, 0)
-    STATE_MAP_ENTRY_ALL_EX(&AbortFilling, 0, &EnterAbortFilling, 0)
+    STATE_MAP_ENTRY_ALL_EX(&Control, 0, &EnterControl, 0)
     END_STATE_MAP_EX
 
     std::shared_ptr<sensorsData> updateInterface(const UOSMData *smdata, States state);

--- a/projects/ServoControl/config/UOStateMachine.h
+++ b/projects/ServoControl/config/UOStateMachine.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "config/config.h"
+#include "stateMachine/InterfacingStateMachine.h"
+#include "helpers/Types.h"
+#include "data/UOSMData.h"
+
+class UOStateMachine : public InterfacingStateMachine
+{
+public:
+    UOStateMachine();
+
+    // External events taken by this state machine
+    void StartFillingEXT();
+    void StopFillingEXT();
+    void AbortFillingEXT();
+    void DoneEXT();
+
+    void updateHotFire(UOSMData *data);
+
+protected:
+
+#if !TESTING
+    InterfaceImpl interfaceImpl;
+#else
+    TestingInterface interfaceImpl;
+#endif
+
+private:
+    void detectExternEvent(std::shared_ptr<sensorsData> data);
+    void showInfo(std::shared_ptr<sensorsData> data);
+
+    // State enumeration order must match the order of state method entries
+    // in the state map.
+    enum States
+    {
+        ST_INIT,
+        ST_WAIT_FOR_INIT,
+        ST_WAIT_FOR_FILLING,
+        ST_FILLING,
+        ST_DONE,
+        ST_ABORT_FILLING,
+        ST_MAX_STATES
+    };
+
+    // Define the state machine state functions with event data type
+    // Init
+    STATE_DECLARE(UOStateMachine, Init, UOSMData)
+    EXIT_DECLARE(UOStateMachine, ExitInit)
+    // WaitForInit
+    ENTRY_DECLARE(UOStateMachine, EnterWaitForInit, UOSMData)
+    STATE_DECLARE(UOStateMachine, WaitForInit, UOSMData)
+    EXIT_DECLARE(UOStateMachine, ExitWaitForInit)
+    // WaitForFilling
+    ENTRY_DECLARE(UOStateMachine, EnterWaitForFilling, UOSMData)
+    STATE_DECLARE(UOStateMachine, WaitForFilling, UOSMData)
+    EXIT_DECLARE(UOStateMachine, ExitWaitForFilling)
+    // Filling
+    ENTRY_DECLARE(UOStateMachine, EnterFilling, UOSMData)
+    STATE_DECLARE(UOStateMachine, Filling, UOSMData)
+    EXIT_DECLARE(UOStateMachine, ExitFilling)
+    // Done
+    ENTRY_DECLARE(UOStateMachine, EnterDone, UOSMData)
+    STATE_DECLARE(UOStateMachine, Done, UOSMData)
+    // AbortFilling
+    ENTRY_DECLARE(UOStateMachine, EnterAbortFilling, UOSMData)
+    STATE_DECLARE(UOStateMachine, AbortFilling, UOSMData)
+
+    BEGIN_STATE_MAP_EX
+    STATE_MAP_ENTRY_ALL_EX(&Init, 0, 0, &ExitInit)
+    STATE_MAP_ENTRY_ALL_EX(&WaitForInit, 0, &EnterWaitForInit, &ExitWaitForInit)
+    STATE_MAP_ENTRY_ALL_EX(&WaitForFilling, 0, &EnterWaitForFilling, &ExitWaitForFilling)
+    STATE_MAP_ENTRY_ALL_EX(&Filling, 0, &EnterFilling, &ExitFilling)
+    STATE_MAP_ENTRY_ALL_EX(&Done, 0, &EnterDone, 0)
+    STATE_MAP_ENTRY_ALL_EX(&AbortFilling, 0, &EnterAbortFilling, 0)
+    END_STATE_MAP_EX
+
+    std::shared_ptr<sensorsData> updateInterface(const UOSMData *smdata, States state);
+};


### PR DESCRIPTION
Added a ServoControl project which implements HotFire's states `ST_INIT`, `ST_WAIT_FOR_INIT`, `ST_WAIT_FOR_FILLING`, `ST_FILLING`, `ST_DONE` and `ST_ABORT_FILLING` to make it easier to test all the servos before the HotFire test.

The implementation of each state was just copied over, I couldn't find a way around just copying the code. This means that any changes to the HotFire state machine should be copied to the ServoControl state machine as well.

The new project just imports HotFire's `config.h` and `GpioConfig.h`. I'm not sure if we want that or if the ServoControl should have it's own configs.

Closes #57 