### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu
+RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt install -y git vim ninja-build cmake gcc g++ make libboost-all-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
     "build": { "dockerfile": "Dockerfile" },
+    "postCreateCommand": "git submodule update --init",
     "forwardPorts": [],
     "extensions": [
         "ms-vscode.cpptools",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "build": { "dockerfile": "Dockerfile" },
+    "forwardPorts": [],
+    "extensions": [
+        "ms-vscode.cpptools",
+        "twxs.cmake",
+        "ms-vscode.cmake-tools",
+        "waderyan.gitblame",
+        "github.vscode-pull-request-github",
+        "ms-vsliveshare.vsliveshare",
+        "ms-python.python",
+        "ms-python.python",
+        "notskm.clang-tidy"
+    ]
+}


### PR DESCRIPTION
A dev container let's you start a vscode workspace with all dependencies and extensions installed. The editing will happen in a docker container, so it will ensure that everyone has the same setup. Using the containers vscode extension, the project will be able to be opened as a "container" locally with everything pre-installed.

This also allows you to quickly start a new environment in the web, or connecting remotely to the web from vscode, without even having to install WSL.

![image](https://user-images.githubusercontent.com/12688112/121795411-77526980-cbde-11eb-8ff8-852df1d49d61.png)

![image](https://user-images.githubusercontent.com/12688112/121795425-90f3b100-cbde-11eb-9cf2-e7a6df43ce65.png)

TODO:

- [ ] Clone submodules
- [ ] Clone private submodule (SBG library) https://github.com/microsoft/vscode/issues/109050
- [ ] Add kit configuration (since the images will be consistent)
- [ ] Make sure everything can be build
- [ ] Have other people test it out on their environments
- [ ] Add Clang configuration (maybe)
- [ ] Build docker image automatically to speed up launch?