### PR TITLE
Fix build.yml CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           git submodule init
           git submodule update
       # Build the project
+      - name: Install dependencies
         run: sudo apt-get install libi2c-dev libboost-all-dev protobuf-compiler -y
       - name: "${{ matrix.name }}: Cmake Makefiles"
         run: ${{ matrix.append }} cmake -B ./build -G 'Unix Makefiles'


### PR DESCRIPTION
Seems the `build.yml` CI file got broken when I did a merge a few hours ago. Weird that this passed the checks.