### PR TITLE
Centralize dependencies installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           git submodule update
       # Build the project
       - name: Install dependencies
-        run: sudo apt-get install libi2c-dev libboost-all-dev protobuf-compiler -y
+        run: sudo ./install-dependencies.sh
       - name: "${{ matrix.name }}: Cmake Makefiles"
         run: ${{ matrix.append }} cmake -B ./build -G 'Unix Makefiles'
       - name: "${{ matrix.name }}: Run make"

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -19,7 +19,7 @@ jobs:
           git submodule init
           git submodule update
       - name: Install dependencies
-        run: sudo apt-get install libi2c-dev libboost-system-dev libboost-filesystem-dev -y
+        run: sudo ./install-dependencies.sh
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.4
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
           git submodule init
           git submodule update
       - name: Install dependencies
-        run: sudo apt-get install libi2c-dev libboost-all-dev protobuf-compiler -y
+        run: sudo ./install-dependencies.sh
       - name: Cmake Makefiles
         run: USE_GPIO=1 cmake -B ./build -G 'Unix Makefiles'
       - name: Run make

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if command -v apt >/dev/null; then
+  # For apt-based distros (ex: Debian, Ubuntu, etc.)
+  apt update
+  apt install ninja-build cmake gcc g++ make libi2c-dev libboost-all-dev protobuf-compiler -y
+else
+  echo "Your distro doesn't seem to be supported."
+fi


### PR DESCRIPTION
Create the `install-dependencies.sh` script to centralize our list of dependencies in one place. I'll also update the getting started doc to use this file instead.

Most people (i.e. everyone except me) seem to use a Debian-based distro, so this file is only for Debian-based distros.