### PR TITLE
Change protobuf module to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/cmcqueen/cobs-c
 [submodule "libraries/protobuf-definitions"]
 	path = libraries/protobuf-definitions
-	url = git@github.com:uorocketry/protobuf-definitions.git
+	url = https://github.com/uorocketry/protobuf-definitions.git


### PR DESCRIPTION
It gives access denied errors to people who don't have ssh authentication setup with git.