### PR TITLE
Fix the high CPU usage

### DIFF
--- a/src/IO/ArduinoProxy.cpp
+++ b/src/IO/ArduinoProxy.cpp
@@ -4,6 +4,7 @@
 
 #include "IO/ArduinoEncoder.h"
 #include <spdlog/spdlog.h>
+#include <sys/poll.h>
 
 ArduinoProxy::ArduinoProxy()
 {
@@ -44,6 +45,9 @@ void ArduinoProxy::run()
     std::string data;
     while (true)
     {
+        struct pollfd pfds[1] = {fd, POLLIN};
+        poll(pfds, 1, -1);
+
         while (serialDataAvail(fd) > 0)
         {
             char value = serialGetchar(fd);


### PR DESCRIPTION
Seems like calling `serialDataAvail` in ArduinoProxy was causing high CPU usage. I just added a blocking call right before that will wait until the file descriptor actually has something to read.