### PR TITLE
Prevent sending loop from holding up main thread

### DIFF
--- a/src/IO/tcp/SocketServer.cpp
+++ b/src/IO/tcp/SocketServer.cpp
@@ -74,7 +74,8 @@ void SocketServer::sendingLoop()
         std::unique_lock<std::mutex> lk(sendingMutex);
         sendingCondition.wait_for(lk, MAX_WAIT);
 
-        while (!sendingBuffer.empty())
+        int sentValues = 0;
+        while (!sendingBuffer.empty() && sentValues < 100)
         {
             auto data = sendingBuffer.front();
 
@@ -85,6 +86,7 @@ void SocketServer::sendingLoop()
             }
 
             sendingBuffer.pop_front();
+            sentValues++;
         }
     }
 }


### PR DESCRIPTION
If the sending buffer gets too big, pass the lock back to the main thread.