### PR TITLE
Switch to Protobuf for the Arduino to RPi communication

### DIFF
--- a/src/IO/ArduinoEncoder.h
+++ b/src/IO/ArduinoEncoder.h
@@ -11,7 +11,7 @@ class ArduinoEncoder
     static helper::SharedArray<char> encode(const T &dataOut);
 
     template <typename T>
-    static T decode(const helper::SharedArray<char> &dataIn);
+    static T decode(const char *buffer, int length);
 };
 
 /**
@@ -44,13 +44,13 @@ helper::SharedArray<char> ArduinoEncoder::encode(const T &dataOut)
  * 0x0 byte.
  */
 template <typename T>
-T ArduinoEncoder::decode(const helper::SharedArray<char> &dataIn)
+T ArduinoEncoder::decode(const char *buffer, int length)
 {
     // Remove COBS from data
-    int dataLength = static_cast<int>(dataIn.length) - 2;
+    int dataLength = static_cast<int>(length) - 2;
     std::unique_ptr<char[]> data(new char[dataLength]);
 
-    cobs_decode_result cobsLength = cobs_decode(&data[0], dataLength, &dataIn.data[0], dataIn.length - 1);
+    cobs_decode_result cobsLength = cobs_decode(&data[0], dataLength, buffer, length - 1);
 
     // Parse Protobuf
     T protoObj;

--- a/src/IO/ArduinoProxy.cpp
+++ b/src/IO/ArduinoProxy.cpp
@@ -6,13 +6,9 @@
 #include <spdlog/spdlog.h>
 #include <sys/poll.h>
 
-ArduinoProxy::ArduinoProxy()
-{
-}
+ArduinoProxy::ArduinoProxy() = default;
 
-ArduinoProxy::~ArduinoProxy()
-{
-}
+ArduinoProxy::~ArduinoProxy() = default;
 
 ArduinoProxy *ArduinoProxy::getInstance()
 {
@@ -55,8 +51,7 @@ void ArduinoProxy::run()
 
             if (value == 0x0)
             {
-                RocketryProto::ArduinoOut msg =
-                    ArduinoEncoder::decode<RocketryProto::ArduinoOut>(buffer.data(), buffer.size());
+                auto msg = ArduinoEncoder::decode<RocketryProto::ArduinoOut>(buffer.data(), buffer.size());
 
                 handleArduinoMessage(msg);
 
@@ -102,7 +97,7 @@ void ArduinoProxy::handleArduinoMessage(const RocketryProto::ArduinoOut &arduino
     }
 }
 
-void ArduinoProxy::send(RocketryProto::ArduinoIn data)
+void ArduinoProxy::send(const RocketryProto::ArduinoIn &data)
 {
     if (inititialized)
     {

--- a/src/IO/ArduinoProxy.h
+++ b/src/IO/ArduinoProxy.h
@@ -29,6 +29,8 @@ class ArduinoProxy : IO
     bool inititialized = false;
 
     std::mutex serialMutex;
+
+    void handleArduinoMessage(const RocketryProto::ArduinoOut &arduinoOut);
 };
 
 #endif

--- a/src/IO/ArduinoProxy.h
+++ b/src/IO/ArduinoProxy.h
@@ -15,11 +15,11 @@ class ArduinoProxy : IO
     ArduinoProxy();
     ~ArduinoProxy();
 
-    void initialize();
-    void run();
-    bool isInitialized();
+    void initialize() override;
+    void run() override;
+    bool isInitialized() override;
 
-    void send(RocketryProto::ArduinoIn c);
+    void send(const RocketryProto::ArduinoIn &c);
 
     ArduinoProxy(ArduinoProxy const &) = delete;
     void operator=(ArduinoProxy const &) = delete;

--- a/unitTesting/arduinoEncoderDecoder.cpp
+++ b/unitTesting/arduinoEncoderDecoder.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Encode and decode protobuf message", "[protobuf]")
 
     helper::SharedArray<char> encodedData = ArduinoEncoder::encode(arduinoIn);
 
-    ArduinoIn arduinoIn2 = ArduinoEncoder::decode<ArduinoIn>(encodedData);
+    auto arduinoIn2 = ArduinoEncoder::decode<ArduinoIn>(encodedData.data.get(), encodedData.length);
 
     REQUIRE(arduinoIn2.data_case() == ArduinoIn::kServoInit);
     REQUIRE(arduinoIn2.servoinit().pin() == 1823);


### PR DESCRIPTION
See PRs https://github.com/uorocketry/arduino-io-proxy/pull/4 and https://github.com/uorocketry/protobuf-definitions/pull/1.

This will be helpful too in the future when we want to send other information, say the current servos state.

Sample of the logging messages:

![unknown](https://user-images.githubusercontent.com/12878386/140955019-6971e989-c51f-483c-baa5-c1a6e08e404f.png)
