### PR TITLE
Store and report the current state of GPIO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+git submodule update --init
 mkdir -p build
 cd build
 cmake .. -G "${1:-Ninja}"

--- a/src/IO/ArduinoProxy.cpp
+++ b/src/IO/ArduinoProxy.cpp
@@ -127,4 +127,24 @@ void ArduinoProxy::send(const RocketryProto::ArduinoIn &data)
     }
 }
 
+/**
+ * Returns the state of the pin. If we don't know the state, throws a std::out_of_range.
+ */
+bool ArduinoProxy::getDigitalState(int pin)
+{
+    std::lock_guard<std::mutex> lockGuard(stateMutex);
+
+    return digitalStates.at(pin);
+}
+
+/**
+ * Returns the state of the pin. If we don't know the state, throws a std::out_of_range.
+ */
+int ArduinoProxy::getServoState(int pin)
+{
+    std::lock_guard<std::mutex> lockGuard(stateMutex);
+
+    return servoStates.at(pin);
+}
+
 #endif

--- a/src/IO/ArduinoProxy.cpp
+++ b/src/IO/ArduinoProxy.cpp
@@ -91,6 +91,20 @@ void ArduinoProxy::handleArduinoMessage(const RocketryProto::ArduinoOut &arduino
             SPDLOG_LOGGER_WARN(logger, "Arduino Error: {}", RocketryProto::ErrorTypes_Name(error));
         }
         break;
+    case RocketryProto::ArduinoOut::kServoState: {
+        std::lock_guard<std::mutex> lockGuard(stateMutex);
+
+        const auto &servoState = arduinoOut.servostate();
+        servoStates[servoState.pin()] = servoState.position();
+    }
+    break;
+    case RocketryProto::ArduinoOut::kDigitalState: {
+        std::lock_guard<std::mutex> lockGuard(stateMutex);
+
+        const auto &digitalState = arduinoOut.digitalstate();
+        digitalStates[digitalState.pin()] = digitalState.activated();
+    }
+    break;
     case RocketryProto::ArduinoOut::DATA_NOT_SET:
         SPDLOG_LOGGER_WARN(logger, "Data field not set in Arduino message. ");
         break;

--- a/src/IO/ArduinoProxy.h
+++ b/src/IO/ArduinoProxy.h
@@ -25,6 +25,10 @@ class ArduinoProxy : IO
     void operator=(ArduinoProxy const &) = delete;
 
   private:
+    std::map<unsigned int, bool> digitalStates;
+    std::map<unsigned int, int> servoStates;
+    std::mutex stateMutex;
+
     int fd = 0;
     bool inititialized = false;
 

--- a/src/IO/ArduinoProxy.h
+++ b/src/IO/ArduinoProxy.h
@@ -28,8 +28,8 @@ class ArduinoProxy : IO
     void operator=(ArduinoProxy const &) = delete;
 
   private:
-    std::map<unsigned int, bool> digitalStates;
-    std::map<unsigned int, int> servoStates;
+    std::map<unsigned int, std::pair<bool, std::chrono::time_point<std::chrono::steady_clock>>> digitalStates;
+    std::map<unsigned int, std::pair<int, std::chrono::time_point<std::chrono::steady_clock>>> servoStates;
     std::mutex stateMutex;
 
     int fd = 0;

--- a/src/IO/ArduinoProxy.h
+++ b/src/IO/ArduinoProxy.h
@@ -21,6 +21,9 @@ class ArduinoProxy : IO
 
     void send(const RocketryProto::ArduinoIn &c);
 
+    bool getDigitalState(int pin);
+    int getServoState(int pin);
+
     ArduinoProxy(ArduinoProxy const &) = delete;
     void operator=(ArduinoProxy const &) = delete;
 

--- a/src/IO/InterfaceImpl.cpp
+++ b/src/IO/InterfaceImpl.cpp
@@ -112,6 +112,7 @@ bool InterfaceImpl::updateInputs()
 
 #if USE_GPIO == 1
     latestState->gpioIsInitialized = gpio.isInitialized();
+    latestState->gpioState = gpio.getCurrentState();
 #endif
 
 #if USE_ARDUINO_PROXY == 1

--- a/src/IO/gpio/DigitalOutput.cpp
+++ b/src/IO/gpio/DigitalOutput.cpp
@@ -46,4 +46,20 @@ bool DigitalOutput::setValue(int value)
     return true;
 }
 
+int DigitalOutput::getCurrentState()
+{
+#if USE_ARDUINO_PROXY == 1
+    try
+    {
+        return arduinoProxy->getDigitalState(pinNbr);
+    }
+    catch (std::out_of_range &error)
+    {
+        return -1;
+    }
+#else
+    return -1;
+#endif
+}
+
 #endif

--- a/src/IO/gpio/DigitalOutput.h
+++ b/src/IO/gpio/DigitalOutput.h
@@ -18,6 +18,8 @@ class DigitalOutput : public Output
 
     bool setValue(int value);
 
+    int getCurrentState();
+
   private:
     std::shared_ptr<spdlog::logger> logger;
     std::string name;

--- a/src/IO/gpio/Gpio.cpp
+++ b/src/IO/gpio/Gpio.cpp
@@ -65,6 +65,22 @@ void Gpio::createNewGpioPwmOutput(const std::string &name, int pinNbr, int safeP
     pwmOutputsMap.insert({name, PwmOutput(name, pinNbr, safePosition, softPWM)});
 }
 
+GpioState Gpio::getCurrentState()
+{
+    GpioState state;
+
+    for (auto i : digitalOutputsMap)
+    {
+        state.digitalStateMap.insert({i.first, i.second.getCurrentState()});
+    }
+    for (auto i : pwmOutputsMap)
+    {
+        state.pwmStateMap.insert({i.first, i.second.getCurrentState()});
+    }
+
+    return state;
+}
+
 /**
  * Convert a map with Output to a map with numbers
  */

--- a/src/IO/gpio/Gpio.h
+++ b/src/IO/gpio/Gpio.h
@@ -33,6 +33,8 @@ class Gpio : public IO
 
     GpioData setOutputs(const GpioData &data);
 
+    GpioState getCurrentState();
+
   protected:
     std::mutex mutex;
 

--- a/src/IO/gpio/PwmOutput.cpp
+++ b/src/IO/gpio/PwmOutput.cpp
@@ -71,4 +71,20 @@ bool PwmOutput::setValue(int value)
     return true;
 }
 
+int PwmOutput::getCurrentState()
+{
+#if USE_ARDUINO_PROXY == 1
+    try
+    {
+        return arduinoProxy->getServoState(pinNbr);
+    }
+    catch (std::out_of_range &error)
+    {
+        return -1;
+    }
+#else
+    return -1;
+#endif
+}
+
 #endif

--- a/src/IO/gpio/PwmOutput.h
+++ b/src/IO/gpio/PwmOutput.h
@@ -20,6 +20,8 @@ class PwmOutput : public Output
 
     bool setValue(int value) override;
 
+    int getCurrentState();
+
   private:
     std::shared_ptr<spdlog::logger> logger;
     const std::string name;

--- a/src/data/GpioData.h
+++ b/src/data/GpioData.h
@@ -7,3 +7,9 @@ struct GpioData
     std::map<std::string, int> digitalOutputMap;
     std::map<std::string, int> pwmOutputMap;
 };
+
+struct GpioState
+{
+    std::map<std::string, int> digitalStateMap;
+    std::map<std::string, int> pwmStateMap;
+};

--- a/src/data/sensorsData.cpp
+++ b/src/data/sensorsData.cpp
@@ -100,6 +100,16 @@ std::string sensorsData::convertToReducedString() const
         data += std::to_string(output.second);
         data += ",";
     }
+    for (std::pair<std::string, int> output : gpioState.digitalStateMap)
+    {
+        data += std::to_string(output.second);
+        data += ",";
+    }
+    for (std::pair<std::string, int> output : gpioState.pwmStateMap)
+    {
+        data += std::to_string(output.second);
+        data += ",";
+    }
 #endif
 
 #if USE_LOGGER == 1

--- a/src/data/sensorsData.h
+++ b/src/data/sensorsData.h
@@ -23,6 +23,7 @@ struct sensorsData
 
 #if USE_GPIO == 1
     GpioData gpioData;
+    GpioState gpioState;
     bool gpioIsInitialized = 0;
 #endif
 


### PR DESCRIPTION
This is related to the changes in here: https://github.com/uorocketry/arduino-io-proxy/pull/5

Start reporting to the GroundStation the current state of the servos. This will be useful if we restart the rocket-code but some pins are already initialized and set from a previous run. It also serves as a visual confirmation that everything is working on the Arduino side.

~Missing a PR on the Ground station to display that data. Might do it today if I have time.~ Opened one: https://github.com/uorocketry/rocket-ground-station/pull/69