### PR TITLE
fix: ignore WiringPi compile warnings

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -32,6 +32,9 @@ add_library(WiringPi STATIC ${WIRINGPI_SRC})
 
 target_include_directories(WiringPi PUBLIC ./WiringPi/wiringPi)
 
+# Ignore annoying warnings we can't do anything about
+set_target_properties(WiringPi PROPERTIES COMPILE_FLAGS "-w")
+
 # ---------------
 # spdlog library
 # ---------------


### PR DESCRIPTION
Got too annoyed with it. Anyway, next up is adding `-Wall` for our code! (and `-Werror`?) :grin: 