### PR TITLE
Use Ninja for the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,5 @@ jobs:
       # Build the project
       - name: Install dependencies
         run: sudo ./install-dependencies.sh
-      - name: "${{ matrix.name }}: Cmake Makefiles"
-        run: ${{ matrix.append }} cmake -B ./build -G 'Unix Makefiles'
-      - name: "${{ matrix.name }}: Run make"
-        run: ${{ matrix.append }} cmake --build ./build --target MainLoop
+      - name: "${{ matrix.name }}: Build"
+        run: ${{ matrix.append }} ./build.sh

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Git reset
         run: git reset --hard
       - name: Run OctoberSky1 Test
-        run: cd ./tests/octoberSky/; bash ./run_test.sh "Unix Makefiles"
+        run: cd ./tests/octoberSky/; bash ./run_test.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,9 +15,9 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: sudo ./install-dependencies.sh
-      - name: Cmake Makefiles
-        run: USE_GPIO=1 cmake -B ./build -G 'Unix Makefiles'
-      - name: Run make
+      - name: CMake
+        run: USE_GPIO=1 cmake -B ./build -G 'Ninja'
+      - name: Build
         run: USE_GPIO=1 cmake --build ./build --target tests
       - name: Run Unit Tests
         run: ./build/unitTesting/tests


### PR DESCRIPTION
Don't quite remember why we were using Make instead. Anyway, now that by default everything (including the RPi) is using Ninja, it makes more sense to have the CI use the same. It also makes using `act` way faster.