### PR TITLE
Add development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    build-essential \
+    cmake \
+    ninja-build \
+    libi2c-dev \
+    libboost-all-dev \
+    protobuf-compiler \
+    libprotobuf-dev \
+    libsystemd-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "DebDevCon",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"settings": {},
+	"extensions": [
+		"ms-vscode.cpptools-extension-pack"
+	],
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
This small PR adds a preconfigured [development container](https://code.visualstudio.com/docs/remote/containers) that should work on vscode out of the box.
For other IDEs such as CLion, some extra configuration is required, but at least you already have a Dockerfile.

For those on Windows, in addition to WSL, development containers facilitate the development by having a standardized development enviroment instead of requiring the developer to manually install the dependencies (and enviroment variables!) 

This also goes for linux too if you're not running an OS that does not use `systemd`