### PR TITLE
Create the DESKTOP_COMPAT flag and move the default log path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ sbgECom/projects/unix/out
 .idea
 
 # Logs
-logs
+logs/
+sensor-data/
 
 boost_1_76_0.tar.bz2
 boost_1_76_0/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,69 +5,73 @@ project(RocketCode2020 C CXX)
 cmake_host_system_information(RESULT _memfree QUERY AVAILABLE_PHYSICAL_MEMORY)
 set_property(GLOBAL PROPERTY JOB_POOLS four_jobs=4)
 if (_memfree LESS 1000)
-	set(CMAKE_JOB_POOL_COMPILE four_jobs)
-endif()
+    set(CMAKE_JOB_POOL_COMPILE four_jobs)
+endif ()
 
 add_subdirectory(./libraries)
 
 if (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
-	add_compile_definitions(HOTFIRE_TEST=$ENV{HOTFIRE_TEST})
-endif()
+    add_compile_definitions(HOTFIRE_TEST=$ENV{HOTFIRE_TEST})
+endif ()
 
 if (DEFINED ENV{USE_LOGGER} OR USE_LOGGER)
-	add_compile_definitions(USE_LOGGER=$ENV{USE_LOGGER})
-endif()
+    add_compile_definitions(USE_LOGGER=$ENV{USE_LOGGER})
+endif ()
 
 if (DEFINED ENV{USE_SOCKET_CLIENT} OR USE_SOCKET_CLIENT)
-	add_compile_definitions(USE_SOCKET_CLIENT=$ENV{USE_SOCKET_CLIENT})
-endif()
+    add_compile_definitions(USE_SOCKET_CLIENT=$ENV{USE_SOCKET_CLIENT})
+endif ()
 
 if (DEFINED ENV{USE_INPUT} OR USE_INPUT)
-	add_compile_definitions(USE_INPUT=$ENV{USE_INPUT})
-endif()
+    add_compile_definitions(USE_INPUT=$ENV{USE_INPUT})
+endif ()
 
 if (DEFINED ENV{SKIP_INIT} OR SKIP_INIT)
-	add_compile_definitions(SKIP_INIT=$ENV{SKIP_INIT})
-endif()
+    add_compile_definitions(SKIP_INIT=$ENV{SKIP_INIT})
+endif ()
 
 if (DEFINED ENV{TESTING} OR TESTING)
-	add_compile_definitions(TESTING=$ENV{TESTING})
-endif()
+    add_compile_definitions(TESTING=$ENV{TESTING})
+endif ()
 
-# Sensors
+if (DEFINED ENV{DESKTOP_COMPAT} OR DESKTOP_COMPAT)
+    add_compile_definitions(DESKTOP_COMPAT=$ENV{DESKTOP_COMPAT})
+endif ()
+
+#Sensors
 
 if (DEFINED ENV{USE_SBG} OR USE_SBG)
-	add_compile_definitions(USE_SBG=$ENV{USE_SBG})
-endif()
+    add_compile_definitions(USE_SBG=$ENV{USE_SBG})
+endif ()
 
 if (DEFINED ENV{USE_RADIO} OR USE_RADIO)
-	add_compile_definitions(USE_RADIO=$ENV{USE_RADIO})
-endif()
+    add_compile_definitions(USE_RADIO=$ENV{USE_RADIO})
+endif ()
 
 if (DEFINED ENV{USE_WIRING_Pi} OR USE_WIRING_Pi)
-	add_compile_definitions(USE_WIRING_Pi=$ENV{USE_WIRING_Pi})
-endif()
+    add_compile_definitions(USE_WIRING_Pi=$ENV{USE_WIRING_Pi})
+endif ()
 
 if (DEFINED ENV{USE_GPIO} OR USE_GPIO)
-	add_compile_definitions(USE_GPIO=$ENV{USE_GPIO})
-endif()
+    add_compile_definitions(USE_GPIO=$ENV{USE_GPIO})
+endif ()
 
 if (DEFINED ENV{USE_ARDUINO_PROXY} OR USE_ARDUINO_PROXY)
-	add_compile_definitions(USE_ARDUINO_PROXY=$ENV{USE_ARDUINO_PROXY})
-endif()
+    add_compile_definitions(USE_ARDUINO_PROXY=$ENV{USE_ARDUINO_PROXY})
+endif ()
 
-# ---------------
-# Main executable
-# ---------------
-find_package (Threads)
+#-- -- -- -- -- -- -- -
+#Main executable
+#-- -- -- -- -- -- -- -
+find_package(Threads)
 
 if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
-	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/ServoControl/*.cpp)
+    file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/ServoControl/*.cpp)
 elseif (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
-	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/HotFire/*.cpp)
-else()
-	file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/OctoberSky1/*.cpp)
-endif()
+    file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/HotFire/*.cpp)
+else ()
+    file(GLOB_RECURSE MAIN_CONFIG_SRC ${PROJECT_SOURCE_DIR}/projects/OctoberSky1/*.cpp)
+endif ()
 
 file(GLOB_RECURSE SRC_MAIN ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
@@ -78,21 +82,21 @@ target_include_directories(MainLoopLib PUBLIC ./src/)
 target_precompile_headers(MainLoopLib PUBLIC ${PROJECT_SOURCE_DIR}/src/common/pch.h)
 
 if (DEFINED ENV{SERVO_CONTROL} OR SERVO_CONTROL)
-	target_include_directories(MainLoopLib PUBLIC
-			./projects/ServoControl/
-	)
-	target_include_directories(MainLoopLib PUBLIC
-			./projects/HotFire/
-	)
+    target_include_directories(MainLoopLib PUBLIC
+            ./projects/ServoControl/
+            )
+    target_include_directories(MainLoopLib PUBLIC
+            ./projects/HotFire/
+            )
 elseif (DEFINED ENV{HOTFIRE_TEST} OR HOTFIRE_TEST)
-	target_include_directories(MainLoopLib PUBLIC
-			./projects/HotFire/
-	)
-else()
-	target_include_directories(MainLoopLib PUBLIC
-			./projects/OctoberSky1/
-	)
-endif()
+    target_include_directories(MainLoopLib PUBLIC
+            ./projects/HotFire/
+            )
+else ()
+    target_include_directories(MainLoopLib PUBLIC
+            ./projects/OctoberSky1/
+            )
+endif ()
 
 target_link_libraries(MainLoopLib sbgECom)
 add_dependencies(MainLoopLib sbgECom)
@@ -100,21 +104,19 @@ add_dependencies(MainLoopLib sbgECom)
 target_link_libraries(MainLoopLib WiringPi)
 add_dependencies(MainLoopLib WiringPi)
 
-if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm")
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm")
+    target_include_directories(MainLoopLib PUBLIC "$ENV{BOOST_DIRECTORY}")
+    target_link_directories(MainLoopLib PUBLIC "$ENV{BOOST_DIRECTORY}/stage/lib")
+    target_link_libraries(MainLoopLib boost_filesystem boost_system)
 
-	target_include_directories(MainLoopLib PUBLIC "$ENV{BOOST_DIRECTORY}")
-	target_link_directories(MainLoopLib PUBLIC "$ENV{BOOST_DIRECTORY}/stage/lib")
-	target_link_libraries(MainLoopLib boost_filesystem boost_system)
-	
-	target_include_directories(MainLoopLib PUBLIC "$ENV{LIBI2C_DIRECTORY}/include")
-	target_link_directories(MainLoopLib PUBLIC "$ENV{LIBI2C_DIRECTORY}/lib")
-	
-else()
-	target_link_libraries(MainLoopLib systemd)
-	find_package(Boost 1.65.1 COMPONENTS system filesystem REQUIRED)
-	target_include_directories(MainLoopLib PUBLIC ${Boost_INCLUDE_DIRS})
-	target_link_libraries(MainLoopLib ${Boost_LIBRARIES})
-endif()
+    target_include_directories(MainLoopLib PUBLIC "$ENV{LIBI2C_DIRECTORY}/include")
+    target_link_directories(MainLoopLib PUBLIC "$ENV{LIBI2C_DIRECTORY}/lib")
+else ()
+    target_link_libraries(MainLoopLib systemd)
+    find_package(Boost 1.65.1 COMPONENTS system filesystem REQUIRED)
+    target_include_directories(MainLoopLib PUBLIC ${Boost_INCLUDE_DIRS})
+    target_link_libraries(MainLoopLib ${Boost_LIBRARIES})
+endif ()
 
 target_link_libraries(MainLoopLib i2c)
 
@@ -124,9 +126,9 @@ target_link_libraries(MainLoopLib protobufDef)
 
 target_link_libraries(MainLoopLib cobs-c)
 
-target_link_libraries (MainLoopLib ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(MainLoopLib ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries (MainLoopLib i2c)
+target_link_libraries(MainLoopLib i2c)
 add_executable(MainLoop ./src/init/MainLoop.cpp)
 target_link_libraries(MainLoop MainLoopLib)
 

--- a/projects/HotFire/config.h
+++ b/projects/HotFire/config.h
@@ -6,6 +6,11 @@
 
 #define STATEMACHINE HotFireStateMachine
 
+#if DESKTOP_COMPAT == 1
+    #define USE_SENSORS 0
+    #define USE_WIRING_Pi 0
+#endif
+
 #ifndef USE_SBG
     #define USE_SBG 0
 #endif

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd ./build
-./MainLoop
+./build/MainLoop

--- a/src/IO/SensorLogger.cpp
+++ b/src/IO/SensorLogger.cpp
@@ -28,12 +28,10 @@ bool SensorLogger::isInitialized()
 
 void SensorLogger::run()
 {
-    auto path = helper::getEnvOrDefault<std::string>("LOG_PATH", "/data/");
+    auto path = helper::getEnvOrDefault<std::string>("LOG_PATH", "./sensor-data");
     std::string ext = ".uorocketlog";
     if (path.back() != '/')
         path += "/";
-
-    int bootId = getBootId(path);
 
     writingLock = std::unique_lock<std::mutex>(writingMutex);
 
@@ -41,6 +39,8 @@ void SensorLogger::run()
     {
         boost::filesystem::create_directories(path);
     }
+
+    int bootId = getBootId(path);
 
     // bool shouldWriteHeader = !std::experimental::filesystem::exists(path +
     // filename); fileStream = std::make_shared<std::ofstream>(path + filename,

--- a/tests/octoberSky/run_test.sh
+++ b/tests/octoberSky/run_test.sh
@@ -8,8 +8,8 @@ TEST_PATH=/tests/octoberSky/
 
 export TESTING=1
 export TARGET_UPDATE_DURATION_NS=0
-export LOG_PATH="..${TEST_PATH}output/"
-export TESTING_INPUT_FILE="..${TEST_PATH}input.txt"
+export LOG_PATH=".${TEST_PATH}output/"
+export TESTING_INPUT_FILE=".${TEST_PATH}input.txt"
 
 cd ../../
 ./build-and-run.sh "${1}" "MainLoop"


### PR DESCRIPTION
The goal of this PR is to reduce the amount of compile flags we need to run the code on a computer. To achieve this, I have added one flag called `DESKTOP_COMPAT`. If set, anything that can't run on a desktop should be disabled.

At the same time, I also moved the log file location. When running with `./run.sh`, the log files will appear under the `rocket-code-2020/sensor-data` folder. This is fine when developing, only thing is we could look at changing it in the systemd file on the Pi. Maybe put it under `/var/log/rocket-data`?