### PR TITLE
Add Custom logging formatter

### DIFF
--- a/src/IO/ArduinoEncoder.h
+++ b/src/IO/ArduinoEncoder.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "cobs.h"
-#include "helpers/Helper.h"
 #include <memory>
 #include <spdlog/spdlog.h>
 
@@ -9,7 +8,7 @@ class ArduinoEncoder
 {
   public:
     template <typename T>
-    static helper::SharedArray<char> encode(const T &dataOut);
+    static SharedArray<char> encode(const T &dataOut);
 
     template <typename T>
     static T decode(const char *buffer, int length);
@@ -20,7 +19,7 @@ class ArduinoEncoder
  * applied to it, and INCLUDES the ending 0x0 byte, so it can be sent as is.
  */
 template <typename T>
-helper::SharedArray<char> ArduinoEncoder::encode(const T &dataOut)
+SharedArray<char> ArduinoEncoder::encode(const T &dataOut)
 {
     // Convert from Protobuf to byte array
     size_t protoSize = dataOut.ByteSizeLong();
@@ -37,7 +36,7 @@ helper::SharedArray<char> ArduinoEncoder::encode(const T &dataOut)
     cobs_encode(&cobsData[0], cobsSize, &protoData[0], protoSize);
     cobsData[cobsSize - 1] = 0x0;
 
-    return helper::SharedArray<char>{cobsData, static_cast<size_t>(cobsSize)};
+    return SharedArray<char>{cobsData, static_cast<size_t>(cobsSize)};
 }
 
 /**

--- a/src/IO/ArduinoProxy.cpp
+++ b/src/IO/ArduinoProxy.cpp
@@ -120,7 +120,7 @@ void ArduinoProxy::send(const RocketryProto::ArduinoIn &data)
     {
         std::lock_guard<std::mutex> lockGuard(serialMutex);
 
-        helper::SharedArray<char> encodedData = ArduinoEncoder::encode(data);
+        SharedArray<char> encodedData = ArduinoEncoder::encode(data);
 
         serialPutchar(fd, 0);
         for (int i = 0; i < encodedData.length; i++)

--- a/src/IO/InterfaceImpl.cpp
+++ b/src/IO/InterfaceImpl.cpp
@@ -5,6 +5,7 @@
 #include "IO/TestingSensors.h"
 #include "InterfaceImpl.h"
 #include "common/pch.h"
+#include "common/utils.h"
 #include "data/UOSMData.h"
 #include <chrono>
 #include <iostream>
@@ -88,8 +89,7 @@ bool InterfaceImpl::updateInputs()
 {
     latestState = std::make_shared<StateData>();
 
-    latestState->timeStamp =
-        std::chrono::duration_cast<time_point::duration>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    latestState->timeStamp = utils::getMonotonicTimeStamp();
 
 #if USE_SBG == 1
     latestState->sbg = mySbgSensor.getData();

--- a/src/IO/SensorLogger.cpp
+++ b/src/IO/SensorLogger.cpp
@@ -3,9 +3,8 @@
 
 #include "SensorLogger.h"
 
-#include "helpers/Helper.h"
-
 #include "boost/filesystem.hpp"
+#include "common/utils.h"
 #include <iostream>
 #include <mutex>
 #include <spdlog/spdlog.h>
@@ -28,7 +27,7 @@ bool SensorLogger::isInitialized()
 
 void SensorLogger::run()
 {
-    auto path = helper::getEnvOrDefault<std::string>("LOG_PATH", "./sensor-data");
+    auto path = utils::getEnvOrDefault<std::string>("LOG_PATH", "./sensor-data");
     std::string ext = ".uorocketlog";
     if (path.back() != '/')
         path += "/";

--- a/src/IO/TestingSensors.cpp
+++ b/src/IO/TestingSensors.cpp
@@ -2,8 +2,8 @@
 #if TESTING == 1
 
 #include "TestingSensors.h"
+#include "common/utils.h"
 #include "data/StateData.h"
-#include "helpers/Helper.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -16,7 +16,7 @@ void TestingSensors::run()
 void TestingSensors::initialize()
 {
     createThread = false;
-    auto fileName = helper::getEnvOrDefault<std::string>("TESTING_INPUT_FILE", "./data/test-data.csv");
+    auto fileName = utils::getEnvOrDefault<std::string>("TESTING_INPUT_FILE", "./data/test-data.csv");
     std::ifstream logFile(fileName.c_str());
 
     std::string line;

--- a/src/IO/gpio/Gpio.cpp
+++ b/src/IO/gpio/Gpio.cpp
@@ -3,7 +3,6 @@
 
 #include "Gpio.h"
 
-#include "helpers/Helper.h"
 #include <iostream>
 #include <string>
 

--- a/src/common/FileLogFormatter.h
+++ b/src/common/FileLogFormatter.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "pch.h"
+#include "spdlog/pattern_formatter.h"
+#include "utils.h"
+
+/**
+ * Custom formatter for spdlog. Same as default but using the getTimeStamp() function
+ */
+class FileLogFormatter : public spdlog::formatter
+{
+  private:
+    spdlog::pattern_formatter f; // Separate formatter for rest of the log messages
+  public:
+    FileLogFormatter()
+    {
+        auto format = "[%n] [%^%l%$] [%s:%#] %v";
+        f.set_pattern(format);
+    }
+    void format(const spdlog::details::log_msg &msg, spdlog::memory_buf_t &dest) override
+    {
+        auto timeStamp = utils::getMonotonicTimeStamp();
+        dest.append("[" + std::to_string(timeStamp) + "] "); // The only thing we need to change is the time stamp
+        f.format(msg, dest);
+    }
+
+    std::unique_ptr<formatter> clone() const override
+    {
+        return std::make_unique<FileLogFormatter>();
+    }
+};

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -6,3 +6,10 @@ using duration_ns = std::chrono::duration<int64_t, std::nano>;
 using duration_ms = std::chrono::duration<int64_t, std::milli>;
 
 using eventType = long;
+
+template <class T>
+struct SharedArray
+{
+    std::shared_ptr<T[]> data;
+    size_t length;
+};

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,0 +1,7 @@
+#include "common/utils.h"
+
+uint64_t utils::getMonotonicTimeStamp()
+{
+    return std::chrono::duration_cast<time_point::duration>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -2,8 +2,10 @@
 #include "common/pch.h"
 #include <boost/lexical_cast.hpp>
 
-namespace helper
+namespace utils
 {
+
+uint64_t getMonotonicTimeStamp();
 
 template <typename T>
 T getEnvOrDefault(const std::string &envName, T defaultValue)
@@ -12,11 +14,4 @@ T getEnvOrDefault(const std::string &envName, T defaultValue)
     return value ? boost::lexical_cast<T>(value) : defaultValue;
 }
 
-template <class T>
-struct SharedArray
-{
-    std::shared_ptr<T[]> data;
-    size_t length;
-};
-
-} // namespace helper
+} // namespace utils

--- a/src/init/MainLoop.cpp
+++ b/src/init/MainLoop.cpp
@@ -3,10 +3,11 @@
 #include <spdlog/sinks/systemd_sink.h>
 #include <thread>
 
-#include "helpers/Helper.h"
+#include "common/FileLogFormatter.h"
 
 #include "IO/InterfaceImpl.h"
 #include "chrono"
+#include "common/FileLogFormatter.h"
 #include "data/UOSMData.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/dup_filter_sink.h"
@@ -38,9 +39,10 @@ void setup_logging()
     auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
         "logs/global_" + std::to_string(unix_timestamp_x_1000) + ".log");
     file_sink->set_level(FILE_LOGGING_LEVEL);
+    file_sink->set_formatter(std::make_unique<FileLogFormatter>());
     dup_filter->add_sink(file_sink);
 
-    if (helper::getEnvOrDefault<std::string>("INSIDE_SERVICE", "0") == "0")
+    if (utils::getEnvOrDefault<std::string>("INSIDE_SERVICE", "0") == "0")
     {
         // Log to the console
         auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
@@ -89,7 +91,7 @@ int main()
     UOSMData data = UOSMData();
 
     const auto targetUpdateDuration =
-        helper::getEnvOrDefault("TARGET_UPDATE_DURATION_NS", DEFAULT_TARGET_UPDATE_DURATION_NS);
+        utils::getEnvOrDefault("TARGET_UPDATE_DURATION_NS", DEFAULT_TARGET_UPDATE_DURATION_NS);
     uint64_t count = 1;
 
     while (true)

--- a/unitTesting/arduinoEncoderDecoder.cpp
+++ b/unitTesting/arduinoEncoderDecoder.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Encode and decode protobuf message", "[protobuf]")
     arduinoIn.mutable_servoinit()->set_pin(1823);
     arduinoIn.mutable_servoinit()->set_safeposition(1231);
 
-    helper::SharedArray<char> encodedData = ArduinoEncoder::encode(arduinoIn);
+    SharedArray<char> encodedData = ArduinoEncoder::encode(arduinoIn);
 
     auto arduinoIn2 = ArduinoEncoder::decode<ArduinoIn>(encodedData.data.get(), encodedData.length);
 
@@ -29,7 +29,7 @@ TEST_CASE("Last byte is 0x0 when encoding protobuf message", "[protobuf]")
     arduinoIn.mutable_servoinit()->set_pin(1823);
     arduinoIn.mutable_servoinit()->set_safeposition(1231);
 
-    helper::SharedArray<char> encodedData = ArduinoEncoder::encode(arduinoIn);
+    SharedArray<char> encodedData = ArduinoEncoder::encode(arduinoIn);
 
     REQUIRE(encodedData.data.get()[encodedData.length - 1] == 0x0);
 }


### PR DESCRIPTION
fixes: #90 

Replaced the default logging timestamp to `std::chrono::steady_clock` 

**Edit**: also moved files from `helpers` folder to `common`

Before:
![image](https://user-images.githubusercontent.com/26195439/175485969-f11f3258-a4c8-4f60-a885-f448ef7fd1f8.png)

After:
![image](https://user-images.githubusercontent.com/26195439/175485671-287b8843-a114-41f5-873d-1dba76cb717b.png)
